### PR TITLE
Fix "Couldn't find template for digesting" error (4.1-stable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This [Redmine](http://www.redmine.org) plugin makes file attachments be stored o
 
 ## Installation
 1. Make sure Redmine is installed and cd into it's root directory
-2. `git clone -b 4.1-trunk https://github.com/farend/redmine_s3.git plugins/redmine_s3`
+2. `git clone -b 4.1-stable https://github.com/farend/redmine_s3.git plugins/redmine_s3`
 3. `cp plugins/redmine_s3/config/s3.yml.example config/s3.yml`
 4. Edit config/s3.yml with your favourite editor
 5. `bundle install --without development test` for installing this plugin dependencies (if you already did it, doing a `bundle install` again would do no harm)

--- a/lib/redmine_s3/attachments_controller_patch.rb
+++ b/lib/redmine_s3/attachments_controller_patch.rb
@@ -50,7 +50,7 @@ module RedmineS3
           @attachment.increment_download
         end
 
-        if stale?(etag: @attachment.digest)
+        if stale?(etag: @attachment.digest, template: false)
           send_data @attachment.raw_data,
             filename: filename_for_content_disposition(@attachment.filename),
             type: detect_content_type(@attachment),
@@ -63,7 +63,7 @@ module RedmineS3
           raise unless @attachment.thumbnailable?
           digest, raw_data = @attachment.thumbnail(:size => params[:size])
           raise unless raw_data
-          if stale?(etag: digest)
+          if stale?(etag: digest, template: false)
             send_data raw_data,
               filename: filename_for_content_disposition(@attachment.filename),
               type: detect_content_type(@attachment, true),


### PR DESCRIPTION
https://www.redmine.org/issues/20277
"Couldn't find template for digesting" error in the log when sending a thumbnail or an attachment.